### PR TITLE
Prior to loading our Ruby code, require 'jars/setup'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+*.sw*

--- a/Mavenfile
+++ b/Mavenfile
@@ -1,6 +1,6 @@
 #-*- mode: ruby -*-
 
-id 'de.saumya.mojo:jruby-mains:0.3.1'
+id 'de.saumya.mojo:jruby-mains:0.4.0'
 
 repository( :id => 'rso-public-grid',
             :url => 'https://repository.sonatype.org/content/groups/sonatype-public-grid',

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@ DO NOT MODIFIY - GENERATED CODE
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.saumya.mojo</groupId>
   <artifactId>jruby-mains</artifactId>
-  <version>0.3.1</version>
+  <version>0.4.0</version>
   <name>jruby-mains</name>
   <description>a set of main method to launch a jruby application from within a jar or war file or start jetty as executable</description>
   <url>http://github.com/#{github}</url>

--- a/src/it/runnable_jar/Gemfile.lock
+++ b/src/it/runnable_jar/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     diff-lcs (1.2.5)
     equalizer (0.0.9)
     ice_nine (0.11.0)
-    jar-dependencies (0.1.7)
+    jar-dependencies (0.1.15)
     jbundler (0.7.1)
       bundler (~> 1.5)
       jar-dependencies (~> 0.1.7)
@@ -33,6 +33,7 @@ GEM
       maven-tools (~> 1.0.1)
       ruby-maven-libs (= 3.1.1)
     ruby-maven-libs (3.1.1)
+    thread_safe (0.3.4)
     thread_safe (0.3.4-java)
     virtus (1.0.3)
       axiom-types (~> 0.1)
@@ -48,3 +49,6 @@ DEPENDENCIES
   jbundler (= 0.7.1)
   rake (~> 10.3)
   rspec (~> 2.14)
+
+BUNDLED WITH
+   1.10.6

--- a/src/it/runnable_jar_bootstrap/lib/jar-bootstrap.rb
+++ b/src/it/runnable_jar_bootstrap/lib/jar-bootstrap.rb
@@ -1,1 +1,9 @@
+# NOTE: This has to be commented out until the integration tests properly
+# include the `Jars.lock` file in the archive which is required
+#
+#java_import 'org.slf4j.Logger'
+#java_import 'org.slf4j.LoggerFactory'
+#logger = LoggerFactory.getLogger('jruby-mains')
+#logger.info('running')
+
 puts "here I am: #{Dir.pwd.sub( /^.*jruby-mains-[0-9]+/, 'jruby-mains/' )}#{__FILE__.sub( /^.+:/, '' )}"

--- a/src/it/runnable_jar_bootstrap/pom.xml
+++ b/src/it/runnable_jar_bootstrap/pom.xml
@@ -26,6 +26,11 @@
       <artifactId>jruby-mains</artifactId>
       <version>${artifact.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.12</version>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/src/it/runnable_jar_extracting/Gemfile.lock
+++ b/src/it/runnable_jar_extracting/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     diff-lcs (1.2.5)
     equalizer (0.0.9)
     ice_nine (0.11.0)
-    jar-dependencies (0.1.7)
+    jar-dependencies (0.1.15)
     jbundler (0.7.1)
       bundler (~> 1.5)
       jar-dependencies (~> 0.1.7)
@@ -33,6 +33,7 @@ GEM
       maven-tools (~> 1.0.1)
       ruby-maven-libs (= 3.1.1)
     ruby-maven-libs (3.1.1)
+    thread_safe (0.3.4)
     thread_safe (0.3.4-java)
     virtus (1.0.3)
       axiom-types (~> 0.1)
@@ -48,3 +49,6 @@ DEPENDENCIES
   jbundler (= 0.7.1)
   rake (~> 10.3)
   rspec (~> 2.14)
+
+BUNDLED WITH
+   1.10.6

--- a/src/it/runnable_jar_old_jruby/Gemfile.lock
+++ b/src/it/runnable_jar_old_jruby/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     diff-lcs (1.2.5)
     equalizer (0.0.9)
     ice_nine (0.11.0)
-    jar-dependencies (0.1.7)
+    jar-dependencies (0.1.15)
     jbundler (0.7.1)
       bundler (~> 1.5)
       jar-dependencies (~> 0.1.7)
@@ -33,6 +33,7 @@ GEM
       maven-tools (~> 1.0.1)
       ruby-maven-libs (= 3.1.1)
     ruby-maven-libs (3.1.1)
+    thread_safe (0.3.4)
     thread_safe (0.3.4-java)
     virtus (1.0.3)
       axiom-types (~> 0.1)
@@ -48,3 +49,6 @@ DEPENDENCIES
   jbundler (= 0.7.1)
   rake (~> 10.3)
   rspec (~> 2.14)
+
+BUNDLED WITH
+   1.10.6

--- a/src/main/java/de/saumya/mojo/mains/JRubyMain.java
+++ b/src/main/java/de/saumya/mojo/mains/JRubyMain.java
@@ -61,11 +61,11 @@ public class JRubyMain extends Main {
             System.exit(1);
         }
     }
-    
+
     JRubyMain(String bundleDisableSharedGems, String currentDirectory, String jrubyHome) {
         this(bundleDisableSharedGems, currentDirectory, jrubyHome, new RubyInstanceConfig());
     }
-    
+
     JRubyMain(String bundleDisableSharedGems, String currentDirectory, String jrubyHome, RubyInstanceConfig config) {
         super(config);
         // TODO have property to disable hard exit - see warbler
@@ -80,7 +80,7 @@ public class JRubyMain extends Main {
         // we assume the embedded gems are placed at the root of the "archive"
         env.put("GEM_PATH", currentDirectory + "/");
         // make sure we do not inherit it from outside
-        // NOTE: setting it to GEM_PATH will break the extractingMain cases 
+        // NOTE: setting it to GEM_PATH will break the extractingMain cases
         env.put("GEM_HOME", jrubyHome + "/lib/ruby/gems/shared");
 
         if (bundleDisableSharedGems != null) {
@@ -93,7 +93,7 @@ public class JRubyMain extends Main {
         // older jruby-1.7.x does need this
         config.setLoader(JRubyMain.class.getClassLoader());
     }
-    
+
     public Status run(String[] args) {
         // require META-INF/init.rb and WEB-INF/init.rb to load any additional
         // config
@@ -102,9 +102,10 @@ public class JRubyMain extends Main {
         addRequire(newArgs, "META-INF/init");
         addRequire(newArgs, "WEB-INF/init");
         addRequire(newArgs, "META-INF/monkey_patches");
+        newArgs.add(0, "-rjars/setup");
         return super.run(newArgs.toArray(new String[newArgs.size()]));
     }
-    
+
     private void addRequire(List<String> newArgs, String name) {
         if (getClass().getClassLoader().getResource(name + ".rb") != null) {
             newArgs.add(0, "-r" + name);


### PR DESCRIPTION
This commit introduces a use case which cannot currently work because
ruby-maven does not currently generate the Jars.lock inside of the generated
jar file

Fixes #5
