### PR TITLE
Adapt to method signature change in JRuby

### DIFF
--- a/src/main/java/org/jruby/mains/JRubyMain.java
+++ b/src/main/java/org/jruby/mains/JRubyMain.java
@@ -54,11 +54,11 @@ public class JRubyMain extends Main {
         catch (Throwable t) {
             // print out as a nice Ruby backtrace
             System.err.println(ThreadContext
-                    .createRawBacktraceStringFromThrowable(t));
+                    .createRawBacktraceStringFromThrowable(t, false));
             while ((t = t.getCause()) != null) {
                 System.err.println("Caused by:");
                 System.err.println(ThreadContext
-                        .createRawBacktraceStringFromThrowable(t));
+                        .createRawBacktraceStringFromThrowable(t, false));
             }
             System.exit(1);
         }


### PR DESCRIPTION
The signature of this method changed in 9.1.2.0; the second arg was added (in [this commit](https://github.com/jruby/jruby/commit/ea8a70c315dff11e93832adf4f88d514c81faba1).)

And so I keep seeing this when my program dies with a top-level exception:

```
Exception in thread "main" java.lang.NoSuchMethodError: org.jruby.runtime.ThreadContext.createRawBacktraceStringFromThrowable(Ljava/lang/Throwable;)Ljava/lang/String;
    at org.jruby.mains.JRubyMain.main(JRubyMain.java:57)
    at org.jruby.mains.JarMain.main(JarMain.java:6)
```
